### PR TITLE
A simplified API for gum

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,6 @@ Example with special options:
 ```clojure
 (b/gum :table :in (clojure.java.io/input-stream "flavours.csv"))
 ```
-p
 
 All of the rest of the options and usecases _should work_ ™. Please raise issues/PRs for any improvements. Much appreciated!
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ $ bb -Sdeps '{:deps {io.github.lispyclouds/bblgum {:git/sha "7ebae0e2231899fe2a6
 This follows the same [section](https://github.com/charmbracelet/gum#interaction) on the gum repo and all params should work verbatim.
 Run `gum <cmd> --help` to discover all the params and args.
 
-This lib only has _one_ public fns: `bblgum.core/gum`.
+This lib only has _one_ public fn: `bblgum.core/gum`.
 
 ## Standard Usage
 `gum` tries to closely mimic the usage of the CLI tool, so it works like `(gum :COMMAND)`,

--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ Convention:
 The `gum` fn returns a map of exit status of calling gum and the result either as a seq of lines or coerced via `:as`.
 Exceptions are not thrown unless calling gum itself does, the status code is intended for programming for failures.
 
+There is also a simplified API described after examples. 
+
 ```clojure
 (b/gum {:cmd :choose
         :opts {:no-limit true}
@@ -126,6 +128,30 @@ Exceptions are not thrown unless calling gum itself does, the status code is int
 ```
 
 All of the rest of the options and usecases _should work_ ™. Please raise issues/PRs for any improvements. Much appreciated!
+
+## Simplified AP
+You can also use the gum like this:
+
+```clojure-version
+(require '[bblgum.core :as b])
+
+;; Calling command without any args or opts:
+(b/gum :file)
+
+;; Calling a command with args only:
+(b/gum :choose [\"foo\" \"bar\"])
+
+;; Calling a command with args and opts:
+(b/gum :choose [\"foo\" \"bar\"] {:header \"select a foo\"})
+
+;; Calling a command with opts only:
+(b/gum :file [] {:directory true})
+
+;; Calling commands the v1 way:
+(gum {:cmd :file :args ["src"] :opts {:directory true}})
+
+```
+
 
 ## Caveats
 

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ You can also use the gum like this:
 (b/gum :choose [\"foo\" \"bar\"] {:header \"select a foo\"})
 
 ;; Calling a command with opts only:
-(b/gum :file [] {:directory true})
+(b/gum :file [] :opts {:directory true})
 
 ;; Calling commands the v1 way:
 (gum {:cmd :file :args ["src"] :opts {:directory true}})

--- a/README.md
+++ b/README.md
@@ -29,13 +29,15 @@ $ bb -Sdeps '{:deps {io.github.lispyclouds/bblgum {:git/sha "7ebae0e2231899fe2a6
 This follows the same [section](https://github.com/charmbracelet/gum#interaction) on the gum repo and all params should work verbatim.
 Run `gum <cmd> --help` to discover all the params and args.
 
-This lib only has _two_ public fns: `bblgum.core/gum*` (low-level API) and `bblgum.core/gum` (high-level API).
+This lib only has _one_ public fns: `bblgum.core/gum`.
 
-## gum (high-level API)
-This uses `gum*` under the hood, but tries to save as much typing as it can.
-
-It tries to closely mimic the usage of the CLI tool, so it works like `(gum :COMMAND)`,
+## Standard Usage
+`gum` tries to closely mimic the usage of the CLI tool, so it works like `(gum :COMMAND)`,
 `(gum :COMMAND [ARGS])` or `(gum :COMMAND [ARGS] :OPTION VALUE :OPTION2 VALUE)`
+
+```clojure
+(require '[bblgum.core :as b])
+```
 
 Examples:
 ```clojure 
@@ -52,6 +54,7 @@ Examples:
 (gum :choose ["arg1" "arg2"] :header "Choose an option")
 ```
 
+
 There are several special opts, that are handled by the library:
 
 `:in` - An input stream than can be passed to gum
@@ -66,7 +69,70 @@ Example with special options:
 (gum :table :in (io/input-stream f) :height 10)
 ```
 
-## gum* (low-level API)
+### Usage Examples
+
+#### input 
+```clojure 
+(b/gum :choose ["foo" "bar" "baz"] :no-limit true)
+
+{:status 0 :result ("foo" "baz")}
+```
+
+#### write 
+```clojure 
+(b/gum :write)
+```
+
+#### filter
+```clojure
+(b/gum :filter :in (clojure.java.io/input-stream "flavours.txt"))
+
+(b/gum :filter :in (clojure.java.io/input-stream "flavours.txt") :no-limit true)
+```
+
+#### confirm
+
+```clojure
+(b/gum :confirm :as  :bool)
+```
+
+#### file
+
+```clojure
+(b/gum :file ["src"])
+```
+
+#### pager
+
+```clojure
+(b/gum :pager :as :ignored :in (clojure.java.io/input-stream "README.md"))
+```
+
+#### spin
+
+```clojure
+(b/gum :spin ["sleep" "5"] :spinner "line" :title "Buying Bubble Gum...")
+```
+
+### table
+
+```clojure
+(b/gum :table :in (clojure.java.io/input-stream "flavours.csv"))
+```
+p
+
+All of the rest of the options and usecases _should work_ ™. Please raise issues/PRs for any improvements. Much appreciated!
+
+## Caveats
+
+- Since this uses gum which expects an interactive TTY like terminal, this is not possible to be used from editor REPLs like Conjure, CIDER, Calva etc **when jacked-in**.
+  To use this from an editor REPL:
+    - First start the REPL in a terminal, for example in bb for nREPL on port 1667: `bb nrepl-server 1667`.
+    - Connect to the port from the editor of your choice, for example with neovim and conjure: `:ConjureConnect 1667`.
+    - Perform the usual REPL interactions and all the gum output would appear on the terminal and not your editor but the result should be on the editor as expected.
+
+## Low-level API
+This was standard in previous versions of gum, we kept it for full backward compatibility.
 
 Convention:
 - The main command should be passed as a keyword or string to `:cmd`. Required
@@ -88,7 +154,6 @@ Convention:
 The `gum` fn returns a map of exit status of calling gum and the result either as a seq of lines or coerced via `:as`.
 Exceptions are not thrown unless calling gum itself does, the status code is intended for programming for failures.
 
-There is also a simplified API described after examples. 
 
 ```clojure
 (b/gum {:cmd :choose
@@ -98,82 +163,6 @@ There is also a simplified API described after examples.
 {:status 0 :result ("foo" "baz")}
 ```
 
-```clojure
-(require '[bblgum.core :as b])
-```
-
-### input
-
-```clojure
-(b/gum {:cmd  :input
-        :opts {:password true}})
-```
-
-### write
-
-```clojure
-(b/gum {:cmd :write})
-```
-
-### filter
-
-```clojure
-(b/gum {:cmd :filter
-        :in  (clojure.java.io/input-stream "flavours.txt")})
-
-(b/gum {:cmd  :filter
-        :in   (clojure.java.io/input-stream "flavours.txt")
-        :opts {:no-limit true}})
-```
-
-### confirm
-
-```clojure
-(b/gum {:cmd :confirm
-        :as  :bool})
-```
-
-### file
-
-```clojure
-(b/gum {:cmd  :file
-        :args ["src"]})
-```
-
-### pager
-
-```clojure
-(b/gum {:cmd :pager
-        :as  :ignored
-        :in  (clojure.java.io/input-stream "README.md")})
-```
-
-### spin
-
-```clojure
-(b/gum {:cmd  :spin
-        :args ["sleep" "5"]
-        :opts {:spinner "line"
-               :title   "Buying Bubble Gum..."}})
-```
-
-### table
-
-```clojure
-(b/gum {:cmd :table
-        :in  (clojure.java.io/input-stream "flavours.csv")})
-```
-
-All of the rest of the options and usecases _should work_ ™. Please raise issues/PRs for any improvements. Much appreciated!
-
-
-## Caveats
-
-- Since this uses gum which expects an interactive TTY like terminal, this is not possible to be used from editor REPLs like Conjure, CIDER, Calva etc **when jacked-in**.
-  To use this from an editor REPL:
-    - First start the REPL in a terminal, for example in bb for nREPL on port 1667: `bb nrepl-server 1667`.
-    - Connect to the port from the editor of your choice, for example with neovim and conjure: `:ConjureConnect 1667`.
-    - Perform the usual REPL interactions and all the gum output would appear on the terminal and not your editor but the result should be on the editor as expected.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Example with special options:
 
 #### input 
 ```clojure 
-p(b/gum :choose ["foo" "bar" "baz"] :no-limit true)
+(b/gum :choose ["foo" "bar" "baz"] :no-limit true)
 
 {:status 0 :result ("foo" "baz")}
 ```

--- a/README.md
+++ b/README.md
@@ -166,29 +166,6 @@ There is also a simplified API described after examples.
 
 All of the rest of the options and usecases _should work_ ™. Please raise issues/PRs for any improvements. Much appreciated!
 
-## Simplified AP
-You can also use the gum like this:
-
-```clojure-version
-(require '[bblgum.core :as b])
-
-;; Calling command without any args or opts:
-(b/gum :file)
-
-;; Calling a command with args only:
-(b/gum :choose [\"foo\" \"bar\"])
-
-;; Calling a command with args and opts:
-(b/gum :choose [\"foo\" \"bar\"] {:header \"select a foo\"})
-
-;; Calling a command with opts only:
-(b/gum :file [] {:opts {:directory true}})
-
-;; Calling commands the v1 way:
-(gum {:cmd :file :args ["src"] :opts {:directory true}})
-
-```
-
 
 ## Caveats
 

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ You can also use the gum like this:
 (b/gum :choose [\"foo\" \"bar\"] {:header \"select a foo\"})
 
 ;; Calling a command with opts only:
-(b/gum :file [] :opts {:directory true})
+(b/gum :file [] {:opts {:directory true}})
 
 ;; Calling commands the v1 way:
 (gum {:cmd :file :args ["src"] :opts {:directory true}})

--- a/README.md
+++ b/README.md
@@ -42,16 +42,16 @@ This lib only has _one_ public fns: `bblgum.core/gum`.
 Examples:
 ```clojure 
 ;; Command only:
-(gum :file)
+(b/gum :file)
 
 ;; Command with args:
-(gum :choose ["arg1" "arg2"])
+(b/gum :choose ["arg1" "arg2"])
 
 ;; Command with opts:
-(gum :file :directory true)
+(b/gum :file :directory true)
 
 ;; Command with opts and args:
-(gum :choose ["arg1" "arg2"] :header "Choose an option")
+(b/gum :choose ["arg1" "arg2"] :header "Choose an option")
 ```
 
 
@@ -73,7 +73,7 @@ Example with special options:
 
 #### input 
 ```clojure 
-(b/gum :choose ["foo" "bar" "baz"] :no-limit true)
+p(b/gum :choose ["foo" "bar" "baz"] :no-limit true)
 
 {:status 0 :result ("foo" "baz")}
 ```

--- a/README.md
+++ b/README.md
@@ -29,7 +29,44 @@ $ bb -Sdeps '{:deps {io.github.lispyclouds/bblgum {:git/sha "7ebae0e2231899fe2a6
 This follows the same [section](https://github.com/charmbracelet/gum#interaction) on the gum repo and all params should work verbatim.
 Run `gum <cmd> --help` to discover all the params and args.
 
-This lib only has _one_ public fn: `bblgum.core/gum`. This is possibly the tiniest clojure lib!
+This lib only has _two_ public fns: `bblgum.core/gum*` (low-level API) and `bblgum.core/gum` (high-level API).
+
+## gum (high-level API)
+This uses `gum*` under the hood, but tries to save as much typing as it can.
+
+It tries to closely mimic the usage of the CLI tool, so it works like `(gum :COMMAND)`,
+`(gum :COMMAND [ARGS])` or `(gum :COMMAND [ARGS] :OPTION VALUE :OPTION2 VALUE)`
+
+Examples:
+```clojure 
+;; Command only:
+(gum :file)
+
+;; Command with args:
+(gum :choose ["arg1" "arg2"])
+
+;; Command with opts:
+(gum :file :directory true)
+
+;; Command with opts and args:
+(gum :choose ["arg1" "arg2"] :header "Choose an option")
+```
+
+There are several special opts, that are handled by the library:
+
+`:in` - An input stream than can be passed to gum
+`:as` - Coerce the output. Currently supports :bool, :ignored or defaults to a seq of strings
+`:gum-path` - Path to the gum binary. Defaults to `gum`
+
+All other opts are passed to the CLI. Consult `gum CMD --help` to see available options.  
+To pass flags like `--directory` use `:directory true`. Always use full names of the options.
+
+Example with special options:
+```clojure
+(gum :table :in (io/input-stream f) :height 10)
+```
+
+## gum* (low-level API)
 
 Convention:
 - The main command should be passed as a keyword or string to `:cmd`. Required

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Add this to your `bb.edn` or `deps.edn`:
 Sample babashka usage:
 ```console
 $ bb -Sdeps '{:deps {io.github.lispyclouds/bblgum {:git/sha "7ebae0e2231899fe2a6ad44bc9ef5fca64099fcd"}}}' \
-     -e "(require '[bblgum.core :as b]) (b/gum {:cmd :input :opts {:placeholder \"User name:\"}})"
+     -e "(require '[bblgum.core :as b]) (b/gum :input :placeholder \"User name:\")"
 ```
 
 ## Interaction

--- a/src/bblgum/core.clj
+++ b/src/bblgum/core.clj
@@ -1,8 +1,8 @@
 (ns bblgum.core
   (:require [bblgum.impl :as i]))
 
-(defn- gumv1
-  "Main driver fn for using gum: https://github.com/charmbracelet/gum
+(defn gum*
+  "Low level API. If you don't know why you are using `gum*` then you're probably looking for `gum`
 
   Options map:
   cmd: The interaction command. Can be a keyword. Required
@@ -34,66 +34,75 @@
                :bool (zero? exit)
                out)}))
 
+(defn- prepare-options [m]
+  (let [fmted-keys [:opts :in :as :gum-path]
+        fmted (select-keys m fmted-keys)
+        opts (apply dissoc m fmted-keys)]
+    (update fmted :opts merge opts)))
+
 (defn- prepare-cmd-map
+  "Prepares command map to be passed to `gum*`. Tries to be smart and figure out what user wants."
   ([cmd]
    (if (map? cmd)
      cmd
-     (prepare-cmd-map cmd [] {})))
+     (prepare-cmd-map cmd [] nil)))
   ([cmd args-or-opts]
-   (if (map? args-or-opts)
-     (prepare-cmd-map cmd [] args-or-opts)
-     (prepare-cmd-map cmd args-or-opts {}))
-)
-  ([cmd args options]
-   (merge  {:cmd cmd :args args} options)))
-
-(comment
-  "Testing examples"
-  (prepare-cmd-map :file)                                                  ;; => {:cmd :file, :args []}
-  (prepare-cmd-map :choose ["foo" "bar"])                                  ;; => {:cmd :choose, :args ["foo" "bar"]}
-  (prepare-cmd-map :choose ["foo" "bar"] {:opts {:header "select a foo"}}) ;; => {:cmd :choose, :args ["foo" "bar"], :opts {:header "select a foo"}}
-  (prepare-cmd-map {:cmd :file :args ["src"] :opts {:directory true}}) ;; => {:cmd :file, :args ["src"], :opts {:directory true}}
-  (prepare-cmd-map {:cmd :table :in "some.in"})                        ;; => {:cmd :table, :in "some.in"}
-
-  "The arity 2 example, only options"
-  (prepare-cmd-map :files {:opts {:directory true}}) ;; => {:cmd :files, :args [], :opts {:directory true}}
-
-  "The arity 2 exmaple, only args"
-  (prepare-cmd-map :choose ["foo" "bar"]) ;; => {:cmd :choose, :args ["foo" "bar"]}
-  )
+   (if (vector? args-or-opts)
+     (prepare-cmd-map cmd args-or-opts nil)
+     (prepare-cmd-map cmd [] args-or-opts)))
+  ([cmd args & options]
+   (let [args* (if (vector? args) args [])
+         foptions (filter some? options)
+         options* (if (keyword? args) (conj foptions args) foptions)]
+     (merge {:cmd cmd :args args*} (if (seq options*) (prepare-options (apply hash-map options*)) {})))))
 
 (defn gum
-  "Main driver fn for using gum: https://github.com/charmbracelet/gum
+  "High level gum API. Simpler in usage then `gum*`, but uses it under the hood.
 
-  You can use it with one map argument with following keys:
-  cmd: The interaction command. Can be a keyword. Required
-  opts: A map of options to be passed as optional params to gum
-  args: A vec of args to be passed as positional params to gum
-  in: An input stream than can be passed to gum
-  as: Coerce the output. Currently supports :bool, :ignored or defaults to a seq of strings
-  gum-path: Path to the gum binary. Defaults to gum
+  You can call `gum` like this:
 
-  You can also use a simplified API which extracts cmd and args, allowing for slightly less
-  code in many use cases:
+  (gum :command [\"args vector\"] :opt \"value\" :opt2 \"value2\")
 
-  Calling command without any args or opts:
-    (gum :file)
+  There are several special opts, that are handled by the library:
+  :in - An input stream than can be passed to gum
+  :as - Coerce the output. Currently supports :bool, :ignored or defaults to a seq of strings
+  :gum-path - Path to the gum binary. Defaults to gum
 
-  Calling a command with args only:
-    (gum :choose [\"foo\" \"bar\"])
+  All other opts are passed to the `gum` CLI. Consult `gum CMD --help` to see available options.
+  To pass flags like `--directory` use `:directory true`. Always use full names of the options.
 
-  Calling a command with args and opts:
-    (gum :choose [\"foo\" \"bar\"] {:opts {:header \"select a foo\"}})
+  Usage examples
+  --------------
+  Command only:
+  (gum :file)
 
-  Calling a command with opts only:
-    (gum :file {:opts {:directory true}}])
-  
+  Command with args:
+  (gum :choose [\"arg\" \"arg2\"])
+
+  Command with opts:
+  (gum :file :directory true)
+
+  Command with arguments and options:
+  (gum :choose [\"arg1\" \"arg2\"] :header \"Choose an option\")
+
   Returns a map of:
   status: The exit code from gum
   result: The output from the execution: seq of lines or coerced via :as."
   ([cmd]
-   (gumv1 (prepare-cmd-map cmd)))
+   (gum* (prepare-cmd-map cmd)))
   ([cmd args-or-opts]
-   (gumv1 (prepare-cmd-map cmd args-or-opts)))
+   (gum* (prepare-cmd-map cmd args-or-opts)))
   ([cmd args opts]
-   (gumv1 (prepare-cmd-map cmd args opts))))
+   (gum* (prepare-cmd-map cmd args opts))))
+
+(comment
+  "Testing examples"
+  (prepare-cmd-map :file)                                        ;; => {:cmd :file, :args []}
+  (prepare-cmd-map :file :directory true)                        ;; => {:cmd :file, :args [], :opts {:directory true}}
+  (prepare-cmd-map :choose ["foo" "bar"])                        ;; => {:cmd :choose, :args ["foo" "bar"]}
+  (prepare-cmd-map :choose ["foo" "bar"] :header "select a foo") ;; => {:cmd :choose, :args ["foo" "bar"], :opts {:header "select a foo"}}
+  (prepare-cmd-map {:cmd :file :args ["src"] :directory true})   ;; => {:cmd :file, :args ["src"], :directory true}
+  (prepare-cmd-map :table :in "some.in" :height 10)              ;; => {:cmd :table, :args [], :in "some.in", :opts {:height 10}}
+  (prepare-cmd-map {:cmd :table :in "some.in"})                  ;; => {:cmd :table, :in "some.in"}
+  (prepare-cmd-map :table :in "input" :height 10)                ;; => {:cmd :table, :args [], :in "input", :opts {:height 10}}
+  )

--- a/src/bblgum/core.clj
+++ b/src/bblgum/core.clj
@@ -33,23 +33,9 @@
   Returns a map of:
   status: The exit code from gum
   result: The output from the execution: seq of lines or coerced via :as."
-  [cmd & [args & opts]]
-  (when-not
-      (or (keyword? cmd)
-          (string? cmd)) (throw (IllegalArgumentException. "cmd must be a keyword or a string")))
-  (let [{:keys [cmd opts args in as gum-path]} (apply i/prepare-cmd-map cmd args opts)
-        gum-path (or gum-path "gum")
-        with-opts (->> opts
-                       (map (fn [[opt value]]
-                              (str "--" (i/->str opt) "=" (i/multi-opt value))))
-                       (into [gum-path (i/->str cmd)]))
-        out (if (= :ignored as) :inherit :string)
-        args (if (or (empty? args) (= "--" (first args)))
-               args
-               (cons "--" args))
-        {:keys [exit out]} (i/exec (into with-opts args) in out)]
-    {:status exit
-     :result (case as
-               :bool (zero? exit)
-               out)}))
-
+  ([cmd]
+   (i/gum* (i/prepare-cmd-map cmd)))
+  ([cmd args-or-opts]
+   (i/gum* (i/prepare-cmd-map cmd args-or-opts)))
+  ([cmd args & opts]
+   (i/gum* (apply i/prepare-cmd-map cmd args opts))))

--- a/src/bblgum/core.clj
+++ b/src/bblgum/core.clj
@@ -1,38 +1,6 @@
 (ns bblgum.core
   (:require [bblgum.impl :as i]))
 
-(defn- gum*
-  "Low level API. If you don't know why you are using `gum*` then you're probably looking for `gum`
-
-  Options map:
-  cmd: The interaction command. Can be a keyword. Required
-  opts: A map of options to be passed as optional params to gum
-  args: A vec of args to be passed as positional params to gum
-  in: An input stream than can be passed to gum
-  as: Coerce the output. Currently supports :bool, :ignored or defaults to a seq of strings
-  gum-path: Path to the gum binary. Defaults to gum
-
-  Returns a map of:
-  status: The exit code from gum
-  result: The output from the execution: seq of lines or coerced via :as."
-  [{:keys [cmd opts args in as gum-path]}]
-  (when-not cmd
-    (throw (IllegalArgumentException. ":cmd must be provided or non-nil")))
-  (let [gum-path (or gum-path "gum")
-        with-opts (->> opts
-                       (map (fn [[opt value]]
-                              (str "--" (i/->str opt) "=" (i/multi-opt value))))
-                       (into [gum-path (i/->str cmd)]))
-        out (if (= :ignored as) :inherit :string)
-        args (if (or (empty? args) (= "--" (first args)))
-               args
-               (cons "--" args))
-        {:keys [exit out]} (i/exec (into with-opts args) in out)]
-    {:status exit
-     :result (case as
-               :bool (zero? exit)
-               out)}))
-
 (defn gum
   "High level gum API. Simpler in usage then `gum*`, but uses it under the hood.
 
@@ -65,10 +33,21 @@
   Returns a map of:
   status: The exit code from gum
   result: The output from the execution: seq of lines or coerced via :as."
-  ([cmd]
-   (gum* (i/prepare-cmd-map cmd)))
-  ([cmd args-or-opts]
-   (gum* (i/prepare-cmd-map cmd args-or-opts)))
-  ([cmd args & opts]
-   (gum* (apply i/prepare-cmd-map cmd args opts))))
-
+  [cmd & [args & opts]]
+  (let [{:keys [cmd opts args in as gum-path]} (apply i/prepare-cmd-map cmd args opts)]
+    (when-not cmd
+      (throw (IllegalArgumentException. ":cmd must be provided or non-nil")))
+    (let [gum-path (or gum-path "gum")
+          with-opts (->> opts
+                         (map (fn [[opt value]]
+                                (str "--" (i/->str opt) "=" (i/multi-opt value))))
+                         (into [gum-path (i/->str cmd)]))
+          out (if (= :ignored as) :inherit :string)
+          args (if (or (empty? args) (= "--" (first args)))
+                 args
+                 (cons "--" args))
+          {:keys [exit out]} (i/exec (into with-opts args) in out)]
+      {:status exit
+       :result (case as
+                 :bool (zero? exit)
+                 out)})))

--- a/src/bblgum/core.clj
+++ b/src/bblgum/core.clj
@@ -92,7 +92,7 @@
    (gum* (prepare-cmd-map cmd)))
   ([cmd args-or-opts]
    (gum* (prepare-cmd-map cmd args-or-opts)))
-  ([cmd args opts]
+  ([cmd args & opts]
    (gum* (prepare-cmd-map cmd args opts))))
 
 (comment
@@ -102,7 +102,8 @@
   (prepare-cmd-map :choose ["foo" "bar"])                        ;; => {:cmd :choose, :args ["foo" "bar"]}
   (prepare-cmd-map :choose ["foo" "bar"] :header "select a foo") ;; => {:cmd :choose, :args ["foo" "bar"], :opts {:header "select a foo"}}
   (prepare-cmd-map {:cmd :file :args ["src"] :directory true})   ;; => {:cmd :file, :args ["src"], :directory true}
-  (prepare-cmd-map :table :in "some.in" :height 10)              ;; => {:cmd :table, :args [], :in "some.in", :opts {:height 10}}
-  (prepare-cmd-map {:cmd :table :in "some.in"})                  ;; => {:cmd :table, :in "some.in"}
-  (prepare-cmd-map :table :in "input" :height 10)                ;; => {:cmd :table, :args [], :in "input", :opts {:height 10}}
+  (prepare-cmd-map :table :in "some.in" :height 10) ;; => {:cmd :table, :args [], :in "some.in", :opts {:height 10}}
+  (prepare-cmd-map {:cmd :table :in "some.in"})     ;; => {:cmd :table, :in "some.in"}
+  (prepare-cmd-map :table :in "input" :height 10)   ;; => {:cmd :table, :args [], :in "input", :opts {:height 10}}
+  (prepare-cmd-map :confirm ["Are you sure?"] :as :bool :negative "Never" :affirmative "Always") ;; => {:cmd :confirm, :args ["Are you sure?"], :as :bool, :opts {:affirmative "Always", :negative "Never"}}
   )

--- a/src/bblgum/core.clj
+++ b/src/bblgum/core.clj
@@ -93,7 +93,7 @@
   ([cmd args-or-opts]
    (gum* (prepare-cmd-map cmd args-or-opts)))
   ([cmd args & opts]
-   (gum* (prepare-cmd-map cmd args opts))))
+   (gum* (apply prepare-cmd-map cmd args opts))))
 
 (comment
   "Testing examples"
@@ -106,4 +106,5 @@
   (prepare-cmd-map {:cmd :table :in "some.in"})     ;; => {:cmd :table, :in "some.in"}
   (prepare-cmd-map :table :in "input" :height 10)   ;; => {:cmd :table, :args [], :in "input", :opts {:height 10}}
   (prepare-cmd-map :confirm ["Are you sure?"] :as :bool :negative "Never" :affirmative "Always") ;; => {:cmd :confirm, :args ["Are you sure?"], :as :bool, :opts {:affirmative "Always", :negative "Never"}}
+  (gum :confirm ["Це той файл?"] :as :bool :negative "Щось ні" :affirmative "Так!")
   )

--- a/src/bblgum/core.clj
+++ b/src/bblgum/core.clj
@@ -39,8 +39,11 @@
    (if (map? cmd)
      cmd
      (prepare-cmd-map cmd [] {})))
-  ([cmd args]
-   (prepare-cmd-map cmd args {}))
+  ([cmd args-or-opts]
+   (if (map? args-or-opts)
+     (prepare-cmd-map cmd [] args-or-opts)
+     (prepare-cmd-map cmd args-or-opts {}))
+)
   ([cmd args options]
    (merge  {:cmd cmd :args args} options)))
 
@@ -49,8 +52,14 @@
   (prepare-cmd-map :file)                                                  ;; => {:cmd :file, :args []}
   (prepare-cmd-map :choose ["foo" "bar"])                                  ;; => {:cmd :choose, :args ["foo" "bar"]}
   (prepare-cmd-map :choose ["foo" "bar"] {:opts {:header "select a foo"}}) ;; => {:cmd :choose, :args ["foo" "bar"], :opts {:header "select a foo"}}
-  (prepare-cmd-map {:cmd :file :args ["src"] :opts {:directory true}})     ;; => {:cmd :file, :args ["src"], :opts {:directory true}}
-  (prepare-cmd-map {:cmd :table :in "some.in"})                            ;; => {:cmd :table, :in "some.in"}
+  (prepare-cmd-map {:cmd :file :args ["src"] :opts {:directory true}}) ;; => {:cmd :file, :args ["src"], :opts {:directory true}}
+  (prepare-cmd-map {:cmd :table :in "some.in"})                        ;; => {:cmd :table, :in "some.in"}
+
+  "The arity 2 example, only options"
+  (prepare-cmd-map :files {:opts {:directory true}}) ;; => {:cmd :files, :args [], :opts {:directory true}}
+
+  "The arity 2 exmaple, only args"
+  (prepare-cmd-map :choose ["foo" "bar"]) ;; => {:cmd :choose, :args ["foo" "bar"]}
   )
 
 (defn gum
@@ -77,14 +86,14 @@
     (gum :choose [\"foo\" \"bar\"] {:opts {:header \"select a foo\"}})
 
   Calling a command with opts only:
-    (gum :file [] {:opts {:directory true}}])
+    (gum :file {:opts {:directory true}}])
   
   Returns a map of:
   status: The exit code from gum
   result: The output from the execution: seq of lines or coerced via :as."
   ([cmd]
    (gumv1 (prepare-cmd-map cmd)))
-  ([cmd args]
-   (gumv1 (prepare-cmd-map cmd args)))
+  ([cmd args-or-opts]
+   (gumv1 (prepare-cmd-map cmd args-or-opts)))
   ([cmd args opts]
    (gumv1 (prepare-cmd-map cmd args opts))))

--- a/src/bblgum/core.clj
+++ b/src/bblgum/core.clj
@@ -2,7 +2,7 @@
   (:require [bblgum.impl :as i]))
 
 (defn gum
-  "High level gum API. Simpler in usage then `gum*`, but uses it under the hood.
+  "Main driver of bblgum.
 
   You can call `gum` like this:
 

--- a/src/bblgum/core.clj
+++ b/src/bblgum/core.clj
@@ -34,7 +34,9 @@
   status: The exit code from gum
   result: The output from the execution: seq of lines or coerced via :as."
   [cmd & [args & opts]]
-  (when-not (keyword? cmd) (throw (IllegalArgumentException. "cmd must be a keyword")))
+  (when-not
+      (or (keyword? cmd)
+          (string? cmd)) (throw (IllegalArgumentException. "cmd must be a keyword or a string")))
   (let [{:keys [cmd opts args in as gum-path]} (apply i/prepare-cmd-map cmd args opts)
         gum-path (or gum-path "gum")
         with-opts (->> opts
@@ -50,3 +52,4 @@
      :result (case as
                :bool (zero? exit)
                out)}))
+

--- a/src/bblgum/core.clj
+++ b/src/bblgum/core.clj
@@ -1,7 +1,7 @@
 (ns bblgum.core
   (:require [bblgum.impl :as i]))
 
-(defn gum
+(defn- gumv1
   "Main driver fn for using gum: https://github.com/charmbracelet/gum
 
   Options map:
@@ -33,3 +33,58 @@
      :result (case as
                :bool (zero? exit)
                out)}))
+
+(defn- prepare-cmd-map
+  ([cmd]
+   (if (map? cmd)
+     cmd
+     (prepare-cmd-map cmd [] {})))
+  ([cmd args]
+   (prepare-cmd-map cmd args {}))
+  ([cmd args options]
+   (merge  {:cmd cmd :args args} options)))
+
+(comment
+  "Testing examples"
+  (prepare-cmd-map :file)                                                  ;; => {:cmd :file, :args []}
+  (prepare-cmd-map :choose ["foo" "bar"])                                  ;; => {:cmd :choose, :args ["foo" "bar"]}
+  (prepare-cmd-map :choose ["foo" "bar"] {:opts {:header "select a foo"}}) ;; => {:cmd :choose, :args ["foo" "bar"], :opts {:header "select a foo"}}
+  (prepare-cmd-map {:cmd :file :args ["src"] :opts {:directory true}})     ;; => {:cmd :file, :args ["src"], :opts {:directory true}}
+  (prepare-cmd-map {:cmd :table :in "some.in"})                            ;; => {:cmd :table, :in "some.in"}
+  )
+
+(defn gum
+  "Main driver fn for using gum: https://github.com/charmbracelet/gum
+
+  You can use it with one map argument with following keys:
+  cmd: The interaction command. Can be a keyword. Required
+  opts: A map of options to be passed as optional params to gum
+  args: A vec of args to be passed as positional params to gum
+  in: An input stream than can be passed to gum
+  as: Coerce the output. Currently supports :bool, :ignored or defaults to a seq of strings
+  gum-path: Path to the gum binary. Defaults to gum
+
+  You can also use a simplified API which extracts cmd and args, allowing for slightly less
+  code in many use cases:
+
+  Calling command without any args or opts:
+    (gum :file)
+
+  Calling a command with args only:
+    (gum :choose [\"foo\" \"bar\"])
+
+  Calling a command with args and opts:
+    (gum :choose [\"foo\" \"bar\"] {:opts {:header \"select a foo\"}})
+
+  Calling a command with opts only:
+    (gum :file [] {:opts {:directory true}}])
+  
+  Returns a map of:
+  status: The exit code from gum
+  result: The output from the execution: seq of lines or coerced via :as."
+  ([cmd]
+   (gumv1 (prepare-cmd-map cmd)))
+  ([cmd args]
+   (gumv1 (prepare-cmd-map cmd args)))
+  ([cmd args opts]
+   (gumv1 (prepare-cmd-map cmd args opts))))

--- a/src/bblgum/core.clj
+++ b/src/bblgum/core.clj
@@ -34,8 +34,8 @@
   status: The exit code from gum
   result: The output from the execution: seq of lines or coerced via :as."
   ([cmd]
-   (i/gum* (i/prepare-cmd-map cmd)))
+   (i/gum cmd))
   ([cmd args-or-opts]
-   (i/gum* (i/prepare-cmd-map cmd args-or-opts)))
+   (i/gum cmd args-or-opts))
   ([cmd args & opts]
-   (i/gum* (apply i/prepare-cmd-map cmd args opts))))
+   (apply i/gum cmd args opts)))

--- a/src/bblgum/core.clj
+++ b/src/bblgum/core.clj
@@ -34,20 +34,19 @@
   status: The exit code from gum
   result: The output from the execution: seq of lines or coerced via :as."
   [cmd & [args & opts]]
-  (let [{:keys [cmd opts args in as gum-path]} (apply i/prepare-cmd-map cmd args opts)]
-    (when-not cmd
-      (throw (IllegalArgumentException. ":cmd must be provided or non-nil")))
-    (let [gum-path (or gum-path "gum")
-          with-opts (->> opts
-                         (map (fn [[opt value]]
-                                (str "--" (i/->str opt) "=" (i/multi-opt value))))
-                         (into [gum-path (i/->str cmd)]))
-          out (if (= :ignored as) :inherit :string)
-          args (if (or (empty? args) (= "--" (first args)))
-                 args
-                 (cons "--" args))
-          {:keys [exit out]} (i/exec (into with-opts args) in out)]
-      {:status exit
-       :result (case as
-                 :bool (zero? exit)
-                 out)})))
+  (when-not (keyword? cmd) (throw (IllegalArgumentException. "cmd must be a keyword")))
+  (let [{:keys [cmd opts args in as gum-path]} (apply i/prepare-cmd-map cmd args opts)
+        gum-path (or gum-path "gum")
+        with-opts (->> opts
+                       (map (fn [[opt value]]
+                              (str "--" (i/->str opt) "=" (i/multi-opt value))))
+                       (into [gum-path (i/->str cmd)]))
+        out (if (= :ignored as) :inherit :string)
+        args (if (or (empty? args) (= "--" (first args)))
+               args
+               (cons "--" args))
+        {:keys [exit out]} (i/exec (into with-opts args) in out)]
+    {:status exit
+     :result (case as
+               :bool (zero? exit)
+               out)}))

--- a/src/bblgum/impl.clj
+++ b/src/bblgum/impl.clj
@@ -83,6 +83,45 @@
          options* (if (keyword? args) (conj foptions args) foptions)]
      (merge {:cmd cmd :args args*} (if (seq options*) (prepare-options (apply hash-map options*)) {})))))
 
+(defn gum
+  "Main driver of bblgum.
+
+  You can call `gum` like this:
+
+  (gum :command [\"args vector\"] :opt \"value\" :opt2 \"value2\")
+
+  There are several special opts, that are handled by the library:
+  :in - An input stream than can be passed to gum
+  :as - Coerce the output. Currently supports :bool, :ignored or defaults to a seq of strings
+  :gum-path - Path to the gum binary. Defaults to gum
+
+  All other opts are passed to the `gum` CLI. Consult `gum CMD --help` to see available options.
+  To pass flags like `--directory` use `:directory true`. Always use full names of the options.
+
+  Usage examples
+  --------------
+  Command only:
+  (gum :file)
+
+  Command with args:
+  (gum :choose [\"arg\" \"arg2\"])
+
+  Command with opts:
+  (gum :file :directory true)
+
+  Command with arguments and options:
+  (gum :choose [\"arg1\" \"arg2\"] :header \"Choose an option\")
+
+  Returns a map of:
+  status: The exit code from gum
+  result: The output from the execution: seq of lines or coerced via :as."
+  ([cmd]
+   (gum* (prepare-cmd-map cmd)))
+  ([cmd args-or-opts]
+   (gum* (prepare-cmd-map cmd args-or-opts)))
+  ([cmd args & opts]
+   (gum* (apply i/prepare-cmd-map cmd args opts))))
+
 (comment
   "Testing examples"
   (prepare-cmd-map :file)                                        ;; => {:cmd :file, :args []}

--- a/src/bblgum/impl.clj
+++ b/src/bblgum/impl.clj
@@ -120,7 +120,7 @@
   ([cmd args-or-opts]
    (gum* (prepare-cmd-map cmd args-or-opts)))
   ([cmd args & opts]
-   (gum* (apply i/prepare-cmd-map cmd args opts))))
+   (gum* (apply prepare-cmd-map cmd args opts))))
 
 (comment
   "Testing examples"

--- a/src/bblgum/impl.clj
+++ b/src/bblgum/impl.clj
@@ -49,13 +49,13 @@
   (let [gum-path (or gum-path "gum")
         with-opts (->> opts
                        (map (fn [[opt value]]
-                              (str "--" (i/->str opt) "=" (i/multi-opt value))))
-                       (into [gum-path (i/->str cmd)]))
+                              (str "--" (->str opt) "=" (multi-opt value))))
+                       (into [gum-path (->str cmd)]))
         out (if (= :ignored as) :inherit :string)
         args (if (or (empty? args) (= "--" (first args)))
                args
                (cons "--" args))
-        {:keys [exit out]} (i/exec (into with-opts args) in out)]
+        {:keys [exit out]} (exec (into with-opts args) in out)]
     {:status exit
      :result (case as
                :bool (zero? exit)

--- a/src/bblgum/impl.clj
+++ b/src/bblgum/impl.clj
@@ -31,8 +31,8 @@
                        str/split-lines
                        (filter seq))))))
 
-(defn gum*
-  "Low level API. If you don't know why you are using `gum*` then you're probably looking for `gum`
+(defn run
+  "Low level API. If you don't know why you are using `run` then you're probably looking for `gum`
   Options map:
   cmd: The interaction command. Can be a keyword. Required
   opts: A map of options to be passed as optional params to gum
@@ -68,7 +68,7 @@
     (update fmted :opts merge opts)))
 
 (defn prepare-cmd-map
-  "Prepares command map to be passed to `gum*`. Tries to be smart and figure out what user wants."
+  "Prepares command map to be passed to `run`. Tries to be smart and figure out what user wants."
   ([cmd]
    (if (map? cmd)
      cmd
@@ -116,11 +116,11 @@
   status: The exit code from gum
   result: The output from the execution: seq of lines or coerced via :as."
   ([cmd]
-   (gum* (prepare-cmd-map cmd)))
+   (run (prepare-cmd-map cmd)))
   ([cmd args-or-opts]
-   (gum* (prepare-cmd-map cmd args-or-opts)))
+   (run (prepare-cmd-map cmd args-or-opts)))
   ([cmd args & opts]
-   (gum* (apply prepare-cmd-map cmd args opts))))
+   (run (apply prepare-cmd-map cmd args opts))))
 
 (comment
   "Testing examples"

--- a/src/bblgum/impl.clj
+++ b/src/bblgum/impl.clj
@@ -31,6 +31,36 @@
                        str/split-lines
                        (filter seq))))))
 
+(defn gum*
+  "Low level API. If you don't know why you are using `gum*` then you're probably looking for `gum`
+  Options map:
+  cmd: The interaction command. Can be a keyword. Required
+  opts: A map of options to be passed as optional params to gum
+  args: A vec of args to be passed as positional params to gum
+  in: An input stream than can be passed to gum
+  as: Coerce the output. Currently supports :bool, :ignored or defaults to a seq of strings
+  gum-path: Path to the gum binary. Defaults to gum
+  Returns a map of:
+  status: The exit code from gum
+  result: The output from the execution: seq of lines or coerced via :as."
+  [{:keys [cmd opts args in as gum-path]}]
+  (when-not cmd
+    (throw (IllegalArgumentException. ":cmd must be provided or non-nil")))
+  (let [gum-path (or gum-path "gum")
+        with-opts (->> opts
+                       (map (fn [[opt value]]
+                              (str "--" (i/->str opt) "=" (i/multi-opt value))))
+                       (into [gum-path (i/->str cmd)]))
+        out (if (= :ignored as) :inherit :string)
+        args (if (or (empty? args) (= "--" (first args)))
+               args
+               (cons "--" args))
+        {:keys [exit out]} (i/exec (into with-opts args) in out)]
+    {:status exit
+     :result (case as
+               :bool (zero? exit)
+               out)}))
+
 (defn prepare-options [m]
   (let [fmted-keys [:opts :in :as :gum-path]
         fmted (select-keys m fmted-keys)

--- a/src/bblgum/impl.clj
+++ b/src/bblgum/impl.clj
@@ -30,3 +30,38 @@
                        str/trim
                        str/split-lines
                        (filter seq))))))
+
+(defn prepare-options [m]
+  (let [fmted-keys [:opts :in :as :gum-path]
+        fmted (select-keys m fmted-keys)
+        opts (apply dissoc m fmted-keys)]
+    (update fmted :opts merge opts)))
+
+(defn prepare-cmd-map
+  "Prepares command map to be passed to `gum*`. Tries to be smart and figure out what user wants."
+  ([cmd]
+   (if (map? cmd)
+     cmd
+     (prepare-cmd-map cmd [] nil)))
+  ([cmd args-or-opts]
+   (if (vector? args-or-opts)
+     (prepare-cmd-map cmd args-or-opts nil)
+     (prepare-cmd-map cmd [] args-or-opts)))
+  ([cmd args & options]
+   (let [args* (if (vector? args) args [])
+         foptions (filter some? options)
+         options* (if (keyword? args) (conj foptions args) foptions)]
+     (merge {:cmd cmd :args args*} (if (seq options*) (prepare-options (apply hash-map options*)) {})))))
+
+(comment
+  "Testing examples"
+  (prepare-cmd-map :file)                                        ;; => {:cmd :file, :args []}
+  (prepare-cmd-map :file :directory true)                        ;; => {:cmd :file, :args [], :opts {:directory true}}
+  (prepare-cmd-map :choose ["foo" "bar"])                        ;; => {:cmd :choose, :args ["foo" "bar"]}
+  (prepare-cmd-map :choose ["foo" "bar"] :header "select a foo") ;; => {:cmd :choose, :args ["foo" "bar"], :opts {:header "select a foo"}}
+  (prepare-cmd-map {:cmd :file :args ["src"] :directory true})   ;; => {:cmd :file, :args ["src"], :directory true}
+  (prepare-cmd-map :table :in "some.in" :height 10) ;; => {:cmd :table, :args [], :in "some.in", :opts {:height 10}}
+  (prepare-cmd-map {:cmd :table :in "some.in"})     ;; => {:cmd :table, :in "some.in"}
+  (prepare-cmd-map :table :in "input" :height 10)   ;; => {:cmd :table, :args [], :in "input", :opts {:height 10}}
+  (prepare-cmd-map :confirm ["Are you sure?"] :as :bool :negative "Never" :affirmative "Always") ;; => {:cmd :confirm, :args ["Are you sure?"], :as :bool, :opts {:affirmative "Always", :negative "Never"}}
+  )

--- a/test/bblgum/impl_test.clj
+++ b/test/bblgum/impl_test.clj
@@ -26,3 +26,25 @@
   (t/testing "exec with in"
     (t/is (= {:exit 0 :out ["21"]}
              (i/exec ["wc" "-l"] (io/input-stream "LICENSE") :string)))))
+
+(t/deftest prepare-cmd-map-test
+  (t/testing "Testing examples"
+    (t/is (= (i/prepare-cmd-map :file)
+             {:cmd :file, :args []}))
+    (t/is (= (i/prepare-cmd-map :file :directory true)
+             {:cmd :file, :args [], :opts {:directory true}}))
+    (t/is (= (i/prepare-cmd-map :choose ["foo" "bar"])
+             {:cmd :choose, :args ["foo" "bar"]}))
+    (t/is (= (i/prepare-cmd-map :choose ["foo" "bar"] :header "select a foo")
+             {:cmd :choose, :args ["foo" "bar"], :opts {:header "select a foo"}}))
+    (t/is (= (i/prepare-cmd-map {:cmd :file :args ["src"] :directory true})
+             {:cmd :file, :args ["src"], :directory true}))
+    (t/is (= (i/prepare-cmd-map :table :in "some.in" :height 10)
+             {:cmd :table, :args [], :in "some.in", :opts {:height 10}}))
+    (t/is (= (i/prepare-cmd-map {:cmd :table :in "some.in"})
+             {:cmd :table, :in "some.in"}))
+    (t/is (= (i/prepare-cmd-map :table :in "input" :height 10)
+             {:cmd :table, :args [], :in "input", :opts {:height 10}}))
+    (t/is (= (i/prepare-cmd-map :confirm ["Are you sure?"] :as :bool :negative "Never" :affirmative "Always")
+             {:cmd :confirm, :args ["Are you sure?"], :as :bool, :opts {:affirmative "Always", :negative "Never"}}))
+    ))


### PR DESCRIPTION
After spending several hours scripting with gum I came up with a slightly simpler API. The new version of `gum` can be used as a drop in replacement for the old one, so nobody gets hurt.

Examples of using the new version:

```clojure
  (prepare-cmd-map :file)                                                  ;; => {:cmd :file, :args []}
  (prepare-cmd-map :choose ["foo" "bar"])                                  ;; => {:cmd :choose, :args ["foo" "bar"]}
  (prepare-cmd-map :choose ["foo" "bar"] {:opts {:header "select a foo"}}) ;; => {:cmd :choose, :args ["foo" "bar"], :opts {:header "select a foo"}}
  (prepare-cmd-map {:cmd :file :args ["src"] :opts {:directory true}})     ;; => {:cmd :file, :args ["src"], :opts {:directory true}}
  (prepare-cmd-map {:cmd :table :in "some.in"})                            ;; => {:cmd :table, :in "some.in"}

```

If you like this approach, I'll also add some tests for the pure part of the PR (`prepare-cmd-map`). Thanks for the library!